### PR TITLE
add import copy

### DIFF
--- a/platform.py
+++ b/platform.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import copy
 
 from platformio.managers.platform import PlatformBase
 


### PR DESCRIPTION
Issue 8
missing `import copy`
python throws error on line 135 where the script call `copy.deepcopy`