### PR TITLE
Fix "program_fpga" target errors

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -213,7 +213,7 @@ env.AddPlatformTarget(
                     "scripts",
                 ),
                 "-c",
-                '"set BITFILE {$SOURCE}"',
+                '"set BITFILE {"$SOURCE"}"',
                 "-f",
                 "%s_program.cfg" % env.subst("$BOARD")
             ]


### PR DESCRIPTION
A path with spaces fails to upload as openocd will recognize an unexpected command line argument. Wrapping $SORUCE in quotes in the argument prevents openocd from recognizing the character after a space as a command line argument.